### PR TITLE
drop 32bit platform support for iOS (i.e. monotouch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ Writes [Serilog](https://serilog.net) events to the console of Xamarin.iOS (NSLo
 Install from [NuGet](https://nuget.org/packages/serilog.sinks.xamarin):
 
 ```powershell
-Install-Package Serilog.Sinks.Xamarin -Pre
+Install-Package Serilog.Sinks.Xamarin
 ```
 
 When using Xamarin.iOS
 
 ```csharp
 Log.Logger = new LoggerConfiguration()
-    .WriteTo.NSLog();
-    .CreateLogger()
+    .WriteTo.NSLog()
+    .CreateLogger();
 ```
 
 When using Xamarin.Android
@@ -23,8 +23,8 @@ When using Xamarin.Android
 
 ```csharp
 Log.Logger = new LoggerConfiguration()
-    .WriteTo.AndroidLog();
-    .CreateLogger()
+    .WriteTo.AndroidLog()
+    .CreateLogger();
 ```
 
 Within your portable class libary or within your application

--- a/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
+++ b/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
@@ -6,7 +6,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{7E96D14B-2224-4EB9-B26B-6306D225024F}</ProjectGuid>
-    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Serilog.Sinks.Xamarin</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
@@ -47,9 +47,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="monotouch" />
+    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="..\Serilog.Sinks.Xamarin.nuspec">

--- a/src/Serilog.Sinks.Xamarin.nuspec
+++ b/src/Serilog.Sinks.Xamarin.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Serilog.Sinks.Xamarin</id>
@@ -11,8 +11,7 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging xamarin android androidlogger monodroid monotouch ios nslog</tags>
     <dependencies>
-      <dependency id="Serilog" />
-      <dependency id="Newtonsoft.Json" />
+      <dependency id="Serilog" version="2.2.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Update

**What is the current behavior? (You can also link to an open issue here)**

The iOS sink references the 32bit monotouch.dll and the latest release of Xamarin will now no longer compile applications or libraries that reference it. Hard [Obsolete] - it throws an MSBuild exception. Ecosystem has had 2.5+ years heads up and warning that this was coming.

**What is the new behavior (if this is a feature change)?**
- The iOS sink now references the 64bit Xamarin.iOS.dll assembly instead.
- CI is now green.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/serilog/serilog#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
