### PR TITLE
Add basic Xamarin.Mac support

### DIFF
--- a/src/Serilog.Sinks.Xamarin.iOS/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Xamarin.iOS/Properties/AssemblyInfo.cs
@@ -1,12 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle("Serilog.Sinks.iOS")]
-[assembly: AssemblyDescription("Serilog sink for Xamarin iOS")]
-[assembly: AssemblyCopyright("Copyright © Serilog Contributors 2016")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +
 													   "6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9" +
 													   "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +

--- a/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
+++ b/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
@@ -1,32 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <ProjectGuid>{7E96D14B-2224-4EB9-B26B-6306D225024F}</ProjectGuid>
-    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RootNamespace>Serilog.Sinks.Xamarin</RootNamespace>
-    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyTitle>Serilog.Sinks.iOS</AssemblyTitle>
     <Description>Serilog sink for Xamarin iOS</Description>
     <Copyright>Copyright © Serilog Contributors 2016</Copyright>
-    <CodesignKey>iPhone Developer</CodesignKey>
-    <ConsolePause>false</ConsolePause>
     <TargetFramework>Xamarin.iOS10</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <OutputPath>bin\iPhone\Debug</OutputPath>
-    <DefineConstants>DEBUG</DefineConstants>
-    <MtouchDebug>true</MtouchDebug>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
-    <OutputPath>bin\iPhone\Release</OutputPath>
     <DocumentationFile>bin\iPhone\$(Configuration)\Serilog.Sinks.Xamarin.iOS.xml</DocumentationFile>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.1.0" />

--- a/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
+++ b/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Serilog.Sinks.iOS</AssemblyTitle>
     <Description>Serilog sink for Xamarin iOS</Description>
     <Copyright>Copyright © Serilog Contributors 2016</Copyright>
-    <TargetFramework>Xamarin.iOS10</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DocumentationFile>bin\iPhone\$(Configuration)\Serilog.Sinks.Xamarin.iOS.xml</DocumentationFile>

--- a/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
+++ b/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
@@ -1,55 +1,32 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{7E96D14B-2224-4EB9-B26B-6306D225024F}</ProjectGuid>
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <OutputType>Library</OutputType>
     <RootNamespace>Serilog.Sinks.Xamarin</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <AssemblyName>Serilog.Sinks.Xamarin.iOS</AssemblyName>
+    <AssemblyTitle>Serilog.Sinks.iOS</AssemblyTitle>
+    <Description>Serilog sink for Xamarin iOS</Description>
+    <Copyright>Copyright © Serilog Contributors 2016</Copyright>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <ConsolePause>false</ConsolePause>
+    <TargetFramework>Xamarin.iOS10</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>bin\iPhone\Debug</OutputPath>
     <DefineConstants>DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <MtouchDebug>true</MtouchDebug>
-    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
-    <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <CodesignKey>iPhone Developer</CodesignKey>
-    <DocumentationFile>bin\iPhone\Release\Serilog.Sinks.Xamarin.iOS.xml</DocumentationFile>
+    <DocumentationFile>bin\iPhone\$(Configuration)\Serilog.Sinks.Xamarin.iOS.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="Sinks\Xamarin\NSLogSink.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="LoggerConfigurationXamarinExtensions.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Xamarin.iOS" />
-  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <None Include="..\Serilog.Sinks.Xamarin.nuspec">
-      <SubType>Designer</SubType>
-    </None>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.1.0" />

--- a/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
+++ b/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Serilog.Sinks.Xamarin</RootNamespace>
     <AssemblyTitle>Serilog.Sinks.iOS</AssemblyTitle>
-    <Description>Serilog sink for Xamarin iOS</Description>
+    <Description>Serilog sink for Xamarin iOS + macOS</Description>
     <Copyright>Copyright © Serilog Contributors 2016</Copyright>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>

--- a/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
+++ b/src/Serilog.Sinks.Xamarin.iOS/Serilog.Sinks.Xamarin.iOS.csproj
@@ -10,6 +10,9 @@
     <DocumentationFile>bin\iPhone\$(Configuration)\Serilog.Sinks.Xamarin.iOS.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="..\Serilog.Sinks.Xamarin.nuspec">
+      <Link>Serilog.Sinks.Xamarin.nuspec</Link>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.1.0" />

--- a/src/Serilog.Sinks.Xamarin.nuspec
+++ b/src/Serilog.Sinks.Xamarin.nuspec
@@ -2,14 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Serilog.Sinks.Xamarin</id>
-    <version>0.1.0</version>
+    <version>0.2.0-beta3</version>
     <authors>Serilog Contributors</authors>
-    <description>Serilog event sink that writes to Xamarin Android AndroidLogger and/or Xamarin iOS NSLOG.</description>
+    <description>Serilog event sink that writes to Xamarin Android AndroidLogger
+and/or Xamarin iOS + macOS NSLog.</description>
     <language>en-US</language>
     <projectUrl>http://serilog.net</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
-    <tags>serilog logging xamarin android androidlogger monodroid monotouch ios nslog</tags>
+    <tags>serilog logging xamarin android androidlogger monodroid monotouch ios macos nslog</tags>
     <dependencies>
       <dependency id="Serilog" version="2.2.0" />
     </dependencies>
@@ -17,8 +18,10 @@
   <files>
     <file src="Serilog.Sinks.Xamarin.Droid\bin\Release\Serilog.Sinks.Xamarin.Droid.dll" target="lib\MonoAndroid403" />
     <file src="Serilog.Sinks.Xamarin.Droid\bin\Release\Serilog.Sinks.Xamarin.Droid.xml" target="lib\MonoAndroid403" />
-    <file src="Serilog.Sinks.Xamarin.iOS\bin\iPhone\Release\Serilog.Sinks.Xamarin.iOS.dll" target="lib\Xamarin.iOS10" />
-    <file src="Serilog.Sinks.Xamarin.iOS\bin\iPhone\Release\Serilog.Sinks.Xamarin.iOS.xml" target="lib\Xamarin.iOS10" />
+    <file src="Serilog.Sinks.Xamarin.iOS\bin\Release\netstandard2.0\Serilog.Sinks.Xamarin.iOS.dll" target="lib\Xamarin.iOS10" />
+    <file src="Serilog.Sinks.Xamarin.iOS\bin\Release\netstandard2.0\Serilog.Sinks.Xamarin.iOS.xml" target="lib\Xamarin.iOS10" />
+    <file src="Serilog.Sinks.Xamarin.iOS\bin\Release\netstandard2.0\Serilog.Sinks.Xamarin.iOS.dll" target="lib\Xamarin.Mac20" />
+    <file src="Serilog.Sinks.Xamarin.iOS\bin\Release\netstandard2.0\Serilog.Sinks.Xamarin.iOS.xml" target="lib\Xamarin.Mac20" />
   </files>
 </package>
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This uses NSLog on macOS the same way it was already used on iOS.

**Does this PR introduce a breaking change?**

Possibly!

I've rewritten the iOS project to use the new Sdk project style, and I've removed Xamarin-specific dependencies as they weren't being used and impeded the build process.

Therefore, you should test that logging from iOS actually still works. It _should_, though.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/serilog/serilog#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
