### PR TITLE
feat: Adding net6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ FakesAssemblies/
 
 # macOS
 .DS_Store
+/.vs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,10 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2022
+configuration: Release
 install:
   - ps: mkdir -Force ".\artifacts\" | Out-Null
+  - cmd: dotnet workload install maui macos android ios maccatalyst
 build_script:
 - ps: ./Build.ps1 -majorMinor 0.2.0 -revision "$env:APPVEYOR_BUILD_VERSION" -branch "$env:APPVEYOR_REPO_BRANCH"
 test: off

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "2.0.54"
+    "MSBuild.Sdk.Extras": "3.0.44"
   }
 }

--- a/serilog-sinks-xamarin.sln
+++ b/serilog-sinks-xamarin.sln
@@ -1,23 +1,24 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32708.82
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".solution", ".solution", "{D0A9316F-8F65-4C36-9FF4-EAE8E65EC005}"
-ProjectSection(SolutionItems) = preProject
-	CHANGES.md = CHANGES.md
-	LICENSE = LICENSE
-	README.md = README.md
-	.gitignore = .gitignore
-	global.json = global.json
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		CHANGES.md = CHANGES.md
+		global.json = global.json
+		LICENSE = LICENSE
+		README.md = README.md
+		src\Serilog.Sinks.Xamarin.nuspec = src\Serilog.Sinks.Xamarin.nuspec
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{322FD05A-A274-4AF2-99CA-BCCB0B4400F5}"
-ProjectSection(SolutionItems) = preProject
-	appveyor.yml = appveyor.yml
-	Build.ps1 = Build.ps1
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+		Build.ps1 = Build.ps1
+	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Xamarin", "src\Serilog.Sinks.Xamarin\Serilog.Sinks.Xamarin.csproj", "{717384AC-F5BC-44BE-92B0-CC7DAF50CB8A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.Xamarin", "src\Serilog.Sinks.Xamarin\Serilog.Sinks.Xamarin.csproj", "{717384AC-F5BC-44BE-92B0-CC7DAF50CB8A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,5 +33,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {37019599-01BF-43D7-BE49-21A7A56EC8E2}
 	EndGlobalSection
 EndGlobal

--- a/src/Serilog.Sinks.Xamarin.nuspec
+++ b/src/Serilog.Sinks.Xamarin.nuspec
@@ -1,25 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
-    <id>Serilog.Sinks.Xamarin</id>
-    <version>0.2.0</version>
-    <authors>Serilog Contributors</authors>
-    <description>Serilog event sink that writes to Xamarin Android AndroidLogger and/or Xamarin iOS or Xamarin macOS NSLog.</description>
-    <language>en-US</language>
-    <projectUrl>http://serilog.net</projectUrl>
-    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
-    <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
-    <tags>serilog logging xamarin android androidlogger monodroid monotouch ios macos nslog</tags>
-    <dependencies>
-      <dependency id="Serilog" version="2.2.0" />
-    </dependencies>
-  </metadata>
-  <files>
-    <file src="Serilog.Sinks.Xamarin\bin\$configuration$\monoandroid90\Serilog.Sinks.Xamarin.dll" target="lib\MonoAndroid403" />
-    <file src="Serilog.Sinks.Xamarin\bin\$configuration$\monoandroid90\Serilog.Sinks.Xamarin.pdb" target="lib\MonoAndroid403" />
-    <file src="Serilog.Sinks.Xamarin\bin\$configuration$\xamarin.ios10\Serilog.Sinks.Xamarin.dll" target="lib\Xamarin.iOS10" />
-    <file src="Serilog.Sinks.Xamarin\bin\$configuration$\xamarin.ios10\Serilog.Sinks.Xamarin.pdb" target="lib\Xamarin.iOS10" />
-    <file src="Serilog.Sinks.Xamarin\bin\$configuration$\xamarin.mac20\Serilog.Sinks.Xamarin.dll" target="lib\Xamarin.Mac20" />
-    <file src="Serilog.Sinks.Xamarin\bin\$configuration$\xamarin.mac20\Serilog.Sinks.Xamarin.pdb" target="lib\Xamarin.Mac20" />
-  </files>
+	<metadata>
+		<id>Serilog.Sinks.Xamarin</id>
+		<version>0.2.0</version>
+		<authors>Serilog Contributors</authors>
+		<description>Serilog event sink that writes to Xamarin Android AndroidLogger and/or Xamarin iOS or Xamarin macOS NSLog.</description>
+		<language>en-US</language>
+		<projectUrl>http://serilog.net</projectUrl>
+		<licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+		<iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
+		<tags>serilog logging xamarin android androidlogger monodroid monotouch ios macos nslog</tags>
+		<dependencies>
+			<dependency id="Serilog" version="2.1.0" />
+		</dependencies>
+	</metadata>
+	<files>
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\monoandroid90\Serilog.Sinks.Xamarin.dll" target="lib\MonoAndroid403" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\monoandroid90\Serilog.Sinks.Xamarin.pdb" target="lib\MonoAndroid403" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\xamarin.ios10\Serilog.Sinks.Xamarin.dll" target="lib\Xamarin.iOS10" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\xamarin.ios10\Serilog.Sinks.Xamarin.pdb" target="lib\Xamarin.iOS10" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\xamarin.mac20\Serilog.Sinks.Xamarin.dll" target="lib\Xamarin.Mac20" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\xamarin.mac20\Serilog.Sinks.Xamarin.pdb" target="lib\Xamarin.Mac20" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\net6.0-android\Serilog.Sinks.Xamarin.dll" target="lib\net6.0-android31.0" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\net6.0-android\Serilog.Sinks.Xamarin.pdb" target="lib\net6.0-android31.0" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\net6.0-ios\Serilog.Sinks.Xamarin.dll" target="lib\net6.0-ios15.4" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\net6.0-ios\Serilog.Sinks.Xamarin.pdb" target="lib\net6.0-ios15.4" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\net6.0-maccatalyst\Serilog.Sinks.Xamarin.dll" target="lib\net6.0-maccatalyst15.4" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\net6.0-maccatalyst\Serilog.Sinks.Xamarin.pdb" target="lib\net6.0-maccatalyst15.4" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\net6.0-macos\Serilog.Sinks.Xamarin.dll" target="lib\net6.0-macos12.3" />
+		<file src="Serilog.Sinks.Xamarin\bin\$configuration$\net6.0-macos\Serilog.Sinks.Xamarin.pdb" target="lib\net6.0-macos12.3" />
+	</files>
 </package>

--- a/src/Serilog.Sinks.Xamarin/Serilog.Sinks.Xamarin.csproj
+++ b/src/Serilog.Sinks.Xamarin/Serilog.Sinks.Xamarin.csproj
@@ -1,28 +1,45 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
-    <PropertyGroup>
-        <TargetFrameworks>Xamarin.iOS10;Xamarin.Mac20;MonoAndroid90</TargetFrameworks>
-        <NuspecFile>.\src\Serilog.Sinks.Xamarin.nuspec</NuspecFile>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>Xamarin.iOS10;Xamarin.Mac20;MonoAndroid90;net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
+		<NuspecFile>.\src\Serilog.Sinks.Xamarin.nuspec</NuspecFile>
 
-    <ItemGroup>
-        <Compile Remove="Sinks\Xamarin\**\*.cs" />
-        <None Include="Sinks\Xamarin\**\*.cs" />
-    </ItemGroup>
+		<IsMonoAndroid>false</IsMonoAndroid>
+		<IsMonoAndroid Condition="$(TargetFramework.ToLower().StartsWith('monoandroid'))">true</IsMonoAndroid>
 
-    <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
-        <Compile Include="Sinks\Xamarin\apple-common\**\*.cs" />
-    </ItemGroup>
+		<IsXamarinIOS>false</IsXamarinIOS>
+		<IsXamarinIOS Condition="'$(TargetFramework)'=='net6.0-maccatalyst' or $(TargetFramework.ToLower().StartsWith('xamarin.ios'))">true</IsXamarinIOS>
 
-    <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.Mac')) ">
-        <Compile Include="Sinks\Xamarin\apple-common\**\*.cs" />
-    </ItemGroup>
+		<IsXamarinMac>false</IsXamarinMac>
+		<IsXamarinMac Condition="$(TargetFramework.ToLower().StartsWith('xamarin.mac'))">true</IsXamarinMac>
 
-    <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-        <Compile Include="Sinks\Xamarin\android\**\*.cs" />
-    </ItemGroup>
+		<_IsAndroid>false</_IsAndroid>
+		<_IsAndroid Condition="$(IsMonoAndroid) or '$(TargetFramework)'=='net6.0-android'">true</_IsAndroid>
 
-    <ItemGroup>
-        <PackageReference Include="Serilog" Version="2.1.0" />
-  </ItemGroup>
+		<_IsCatalyst>false</_IsCatalyst>
+		<_IsCatalyst Condition="$(_IsCatalyst) or '$(TargetFramework)'=='net6.0-maccatalyst'">true</_IsCatalyst>
+
+		<_IsIOS>false</_IsIOS>
+		<_IsIOS Condition="$(IsXamarinIOS) or '$(TargetFramework)'=='net6.0-ios'">true</_IsIOS>
+
+		<_IsMacOS>false</_IsMacOS>
+		<_IsMacOS Condition="$(IsXamarinMac) or '$(TargetFramework)'=='net6.0-macos'">true</_IsMacOS>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Remove="**\*.cs" />
+		<None Include="**\*.cs" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" $(_IsIOS) or $(_IsCatalyst) or $(_IsMacOS) ">
+		<Compile Include="Sinks\Xamarin\apple-common\**\*.cs" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" $(_IsAndroid) ">
+		<Compile Include="Sinks\Xamarin\android\**\*.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Serilog" Version="2.1.0" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds support for net6 ios, android, mac and catalyst


**What is the current behavior? (You can also link to an open issue here)**
No support for net6 mobile targets


**What is the new behavior (if this is a feature change)?**
None, other than being able to add reference to package


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/serilog/serilog#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

