### PR TITLE
fix: Correcting package suffix for main branch

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -21,7 +21,7 @@ foreach ($src in ls src/*) {
 
 	echo "build: Packaging project in $src"
 
-    & msbuild /r /m /p:Configuration=Release /p:VersionSuffix=$buildSuffix /p:EnableSourceLink=true "/p:PackageOutputPath=..\..\artifacts"
+    & msbuild /r /m /p:Configuration=Release /p:VersionSuffix=$suffix /p:EnableSourceLink=true "/p:PackageOutputPath=..\..\artifacts"
 
     if($LASTEXITCODE -ne 0) { exit 1 }    
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix: Correcting package suffix for main branch


**What is the current behavior? (You can also link to an open issue here)**
packages are being created with suffix in version number eg 1.0.0-main-a6f7331


**What is the new behavior (if this is a feature change)?**
suffix is dropped for main branch


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ X ] The commit follows our guidelines: https://github.com/serilog/serilog#contribute
- [ N/A ] Tests for the changes have been added (for bug fixes / features)
- [ N/A ] Docs have been added / updated (for bug fixes / features)

**Other information**:

