### PR TITLE
Use a different identifier for the Android tag instead of SourceContextPropertyName

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ When using Xamarin.Android
 ```csharp
 Log.Logger = new LoggerConfiguration()
     .WriteTo.AndroidLog()
-    .Enrich.WithProperty(Constants.SourceContextPropertyName, "MyCustomTag") //Sets the Tag field.
+    .Enrich.WithProperty(Constants.AndroidTagPropertyName, "MyCustomTag") //Sets the Tag field.
     .CreateLogger();
 ```
 

--- a/src/Serilog.Sinks.Xamarin/Sinks/Xamarin/android/AndroidLogSink.cs
+++ b/src/Serilog.Sinks.Xamarin/Sinks/Xamarin/android/AndroidLogSink.cs
@@ -20,6 +20,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 using AndroidLog = Android.Util.Log;
+using Constants = Serilog.Sinks.Xamarin.Constants;
 
 namespace Serilog.Sinks.Xamarin
 {
@@ -51,7 +52,7 @@ namespace Serilog.Sinks.Xamarin
 			var renderSpace = new StringWriter();
 			_textFormatter.Format(logEvent, renderSpace);
 
-			var tag = logEvent.Properties.Where(x => x.Key == Constants.SourceContextPropertyName).Select(x => x.Value.ToString("l", null)).FirstOrDefault() ?? "";
+			var tag = logEvent.Properties.Where(x => x.Key == Constants.AndroidTagPropertyName).Select(x => x.Value.ToString("l", null)).FirstOrDefault() ?? "";
 
 			switch (logEvent.Level) {
 				case LogEventLevel.Debug:

--- a/src/Serilog.Sinks.Xamarin/Sinks/Xamarin/android/Constants.cs
+++ b/src/Serilog.Sinks.Xamarin/Sinks/Xamarin/android/Constants.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace Serilog.Sinks.Xamarin
+{
+    public static class Constants
+    {
+        public const string AndroidTagPropertyName = "SerilogAndroidTag";
+    }
+}
+


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix, docs update 

**What is the current behavior? (You can also link to an open issue here)**

The `SourceContextPropertyName` can be overwritten in some situations so the defined `Tag`, as described in the docs, won't work. 

1. Add the Android Logging as designed 
```
.WriteTo.AndroidLog() 
.Enrich.WithProperty(Constants.SourceContextPropertyName, "MyAndroidTag")
```
3. Use in combination with Microsoft's Dependency Injection 
4. Register an `Microsoft.Extensions.Logging.ILogger` implementation 
```csharp
services.AddSingleton<Microsoft.Extensions.Logging.ILogger>
    (provider => provider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<object>>());
```
5. Notice that the SourceContextPropertyName will be "overwritten" and it'll hold "object" as value. 


Snippet for my registration style to repro this: 

```csharp
IServiceCollection services = new ServiceCollection();
services.AddLogging(r =>
{
    r.AddSerilog(logger);
});
services.AddSingleton<Microsoft.Extensions.Logging.ILogger>(provider => provider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<object>>());
```

**What is the new behavior (if this is a feature change)?**

The constant used to identify the Android TAG is changed. It is introduced as part of `Serilog.Sinks.Xamarin.Constants`

**Does this PR introduce a breaking change?**

YES! 

Users updating will need to add/update the enrich property for tag to be `Constants.AndroidTagPropertyName`

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/serilog/serilog#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

